### PR TITLE
Fix SIGTERM after IP connection closed

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,7 +121,7 @@ TexecomPlatform.prototype = {
 			});  
 		} else if (this.ip_address) {
 			try {
-				connection = net.createConnection(this.ip_port, this.ip_address, function() {
+				connection = net.createConnection(platform.ip_port, platform.ip_address, function() {
 					platform.log('Connected via IP');
 				});
 			} catch (err) {
@@ -138,7 +138,7 @@ TexecomPlatform.prototype = {
 			connection.on('close', function() {
 				platform.log('IP connection closed');
 				try {
-					connection = net.createConnection(this.ip_port, this.ip_address, function() {
+					connection = net.createConnection(platform.ip_port, platform.ip_address, function() {
 						platform.log('Re-connected after loss of connection');
 					});
 				} catch (err) {


### PR DESCRIPTION
The IP address and port variables are being lost when the connection close event is fired. This PR ensures the address/port is still populated with the values defined in the config - and prevents a SIGTERM being raised.

Resolves #16 